### PR TITLE
Implement Phase 0 Dashboard Item Lists and Sections

### DIFF
--- a/src/actions/share.ts
+++ b/src/actions/share.ts
@@ -1,0 +1,36 @@
+"use server";
+
+import { beWrite } from "@/util/be";
+
+/**
+ * Toggles the public access status of a brain.
+ */
+export async function shareBrain(brainId: string, isPublic: boolean) {
+  try {
+    // Assuming PUT or POST for updating share settings
+    await beWrite(
+      `/brain/${brainId}/share`,
+      { public: isPublic },
+      { tagsToRevalidate: [`${brainId}:detail`] }
+    );
+  } catch (error) {
+    console.error("Failed to update share settings:", error);
+    throw new Error("Failed to update share settings");
+  }
+}
+
+/**
+ * Invites a user to collaborate on a brain by email.
+ */
+export async function inviteCollaborator(brainId: string, email: string) {
+  try {
+    await beWrite(
+      `/brain/${brainId}/invite`,
+      { email },
+      { tagsToRevalidate: [`${brainId}:detail`] }
+    );
+  } catch (error) {
+    console.error("Failed to invite collaborator:", error);
+    throw new Error("Failed to invite collaborator");
+  }
+}

--- a/src/api/brain-items.ts
+++ b/src/api/brain-items.ts
@@ -1,0 +1,26 @@
+import { beJSON } from "@/util/be";
+import { BrainItem } from "@/types/brain";
+
+/**
+ * Fetch items for a specific brain, optionally filtered by type or search query.
+ */
+export async function getBrainItems(
+  brainId: string,
+  type?: string,
+  search?: string
+): Promise<BrainItem[]> {
+  const params = new URLSearchParams();
+  if (type) params.set("type", type);
+  if (search) params.set("search", search);
+
+  const queryString = params.toString() ? `?${params.toString()}` : "";
+
+  // The README suggests using the tag `${brainId}:all` for lists of items.
+  return beJSON<BrainItem[]>(
+    `/brain/${brainId}/items${queryString}`,
+    {
+      tags: [`${brainId}:all`],
+      revalidate: 10,
+    }
+  );
+}

--- a/src/app/components/brain/item-card.tsx
+++ b/src/app/components/brain/item-card.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { Card, CardHeader, CardBody, CardFooter, Link, Chip } from "@heroui/react";
+import { BrainItem } from "@/types/brain";
+import { Twitter, Youtube, FileText, Video, Link as LinkIcon, MoreHorizontal } from "lucide-react";
+
+const TypeIcon: Record<string, any> = {
+  tweet: Twitter,
+  video: Video,
+  youtube: Youtube,
+  note: FileText,
+  link: LinkIcon,
+  other: MoreHorizontal,
+};
+
+export default function ItemCard({ item }: { item: BrainItem }) {
+  const Icon = TypeIcon[item.type] || FileText;
+
+  return (
+    <Card className="h-full border border-transparent hover:border-default-200 transition-colors shadow-sm">
+      <CardHeader className="flex justify-between items-start gap-2 pb-0">
+        <div className="flex items-center gap-2 min-w-0">
+          <div className="p-1.5 bg-default-100 rounded-md shrink-0 text-default-500">
+             <Icon size={18} />
+          </div>
+          <h4 className="font-semibold text-medium truncate" title={item.title}>
+            {item.title}
+          </h4>
+        </div>
+        {item.pinned && (
+          <Chip size="sm" color="warning" variant="flat" className="shrink-0 h-6">
+            Pinned
+          </Chip>
+        )}
+      </CardHeader>
+
+      <CardBody className="py-3 px-3">
+        {item.type === 'note' ? (
+           <div className="text-small text-default-500 line-clamp-4 whitespace-pre-wrap min-h-[3rem]">
+             {item.content || "No content"}
+           </div>
+        ) : (
+           <div className="min-h-[3rem]">
+             <Link
+               isExternal
+               href={item.url}
+               showAnchorIcon
+               className="text-small text-primary line-clamp-2 break-all"
+             >
+                {item.url}
+             </Link>
+             {item.content && (
+                <p className="mt-2 text-tiny text-default-400 line-clamp-2">
+                    {item.content}
+                </p>
+             )}
+           </div>
+        )}
+
+        {item.tags && item.tags.length > 0 && (
+          <div className="flex flex-wrap gap-1 mt-4">
+            {item.tags.map((t) => (
+              <Chip key={t} size="sm" variant="flat" className="text-tiny h-6">
+                #{t}
+              </Chip>
+            ))}
+          </div>
+        )}
+      </CardBody>
+
+      <CardFooter className="pt-0 pb-3 px-3 text-tiny text-default-400">
+        {new Date(item.createdAt).toLocaleDateString(undefined, {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric'
+        })}
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/app/components/brain/item-list.tsx
+++ b/src/app/components/brain/item-list.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { BrainItem } from "@/types/brain";
+import ItemCard from "./item-card";
+
+export default function ItemList({ items }: { items: BrainItem[] }) {
+  if (!items || items.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 text-default-400 border-2 border-dashed border-default-200 rounded-lg">
+        <p className="text-lg font-medium">No items found</p>
+        <p className="text-sm opacity-70">Add some content to get started.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 animate-in fade-in duration-500">
+      {items.map((item) => (
+        <ItemCard key={item.id} item={item} />
+      ))}
+    </div>
+  );
+}

--- a/src/app/dashboard/[BrainId]/[section]/page.tsx
+++ b/src/app/dashboard/[BrainId]/[section]/page.tsx
@@ -1,0 +1,58 @@
+import { getBrainItems } from "@/api/brain-items";
+import ItemList from "@/app/components/brain/item-list";
+import { auth } from "@/auth";
+import { redirect, notFound } from "next/navigation";
+
+type Params = Promise<{ BrainId: string; section: string }>;
+type SearchParams = Promise<{ [key: string]: string | string[] | undefined }>;
+
+const SECTION_TO_TYPE: Record<string, string> = {
+  tweets: "tweet",
+  videos: "video",
+  docs: "note",
+  links: "link",
+};
+
+export default async function BrainSectionPage(props: {
+  params: Params;
+  searchParams: SearchParams;
+}) {
+  const session = await auth();
+  if (!session?.user) {
+    redirect("/");
+  }
+
+  const { BrainId, section } = await props.params;
+  const searchParams = await props.searchParams;
+  const search = typeof searchParams.search === 'string' ? searchParams.search : undefined;
+
+  // Validate section
+  if (!SECTION_TO_TYPE[section]) {
+     notFound();
+  }
+
+  const type = SECTION_TO_TYPE[section];
+
+  let items = await getBrainItems(BrainId, type, search);
+
+  // If section is videos, also fetch youtube items and merge
+  if (section === 'videos') {
+      const youtubeItems = await getBrainItems(BrainId, 'youtube', search);
+      // Avoid duplicates just in case, though IDs should be unique
+      const existingIds = new Set(items.map(i => i.id));
+      const newItems = youtubeItems.filter(i => !existingIds.has(i.id));
+      items = [...items, ...newItems];
+
+      // Sort by created at descending
+      items.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  }
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold capitalize hidden md:block">
+        {section}
+      </h2>
+      <ItemList items={items} />
+    </div>
+  );
+}

--- a/src/app/dashboard/[BrainId]/error.tsx
+++ b/src/app/dashboard/[BrainId]/error.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect } from "react";
+import { Button } from "@heroui/react";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center h-64 space-y-4 text-center">
+      <h2 className="text-xl font-semibold text-danger">Something went wrong!</h2>
+      <p className="text-default-500 max-w-md">
+        {error.message || "Failed to load brain content. Please try again later."}
+      </p>
+      <Button
+        color="primary"
+        onPress={
+          // Attempt to recover by trying to re-render the segment
+          () => reset()
+        }
+      >
+        Try again
+      </Button>
+    </div>
+  );
+}

--- a/src/app/dashboard/[BrainId]/layout.tsx
+++ b/src/app/dashboard/[BrainId]/layout.tsx
@@ -1,0 +1,50 @@
+import { getBrainDetails } from "@/api/brain-details";
+import BrainHeader from "@/app/components/brain/brain-header";
+import { shareBrain, inviteCollaborator } from "@/actions/share";
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+import { ReactNode } from "react";
+
+type Params = Promise<{ BrainId: string }>;
+
+export default async function BrainLayout(props: {
+  children: ReactNode;
+  params: Params;
+}) {
+  const session = await auth();
+  if (!session?.user) {
+    redirect("/");
+  }
+
+  const { BrainId } = await props.params;
+  const brainDetails = await getBrainDetails(BrainId);
+
+  // Wrapper for server actions to match component signature
+  async function onShareToggle(next: boolean) {
+    "use server";
+    await shareBrain(BrainId, next);
+  }
+
+  async function onInvite(email: string) {
+    "use server";
+    await inviteCollaborator(BrainId, email);
+  }
+
+  return (
+    <div className="p-4 md:p-6 max-w-7xl mx-auto w-full">
+      <BrainHeader
+        brainId={BrainId}
+        name={brainDetails.name}
+        description={brainDetails.description}
+        counts={brainDetails.counts}
+        isPublic={false} // TODO: Add isPublic to BrainDetails type and backend response
+        onShareToggle={onShareToggle}
+        onInviteCollaborator={onInvite}
+        extensionUrl="https://chromewebstore.google.com/detail/your-extension-id"
+      />
+      <div className="mt-6">
+        {props.children}
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/[BrainId]/loading.tsx
+++ b/src/app/dashboard/[BrainId]/loading.tsx
@@ -1,0 +1,9 @@
+import { Spinner } from "@heroui/react";
+
+export default function Loading() {
+  return (
+    <div className="flex justify-center items-center h-64">
+      <Spinner size="lg" color="primary" label="Loading content..." />
+    </div>
+  );
+}

--- a/src/app/dashboard/[BrainId]/page.tsx
+++ b/src/app/dashboard/[BrainId]/page.tsx
@@ -1,55 +1,29 @@
-// import { getBrainAll } from "@/server/queries/brainContent";
-// import type { FeedItem } from "@/types/brain";
-
-import { getBrainDetails } from "@/api/brain-details";
-import BrainHeader from "@/app/components/brain/brain-header";
+import { getBrainItems } from "@/api/brain-items";
+import ItemList from "@/app/components/brain/item-list";
 import { auth } from "@/auth";
 import { redirect } from "next/navigation";
 
-type Params = Promise<{ BrainId: string }>
-type SearchParams = Promise<{ [key: string]: string | string[] | undefined }>
- 
+type Params = Promise<{ BrainId: string }>;
+type SearchParams = Promise<{ [key: string]: string | string[] | undefined }>;
 
-/** Server page for a specific brain's overview. */
 export default async function BrainSpecificAllPage(props: {
-    params: Params
-    searchParams: SearchParams
-  }) {
+  params: Params;
+  searchParams: SearchParams;
+}) {
+  const session = await auth();
+  if (!session?.user) {
+    redirect("/");
+  }
 
-    const session = await auth();
-   
-
-    if(!session?.user) {
-        redirect("/")
-    }
-
-
-  const val = await props.params;
+  const { BrainId } = await props.params;
   const searchParams = await props.searchParams;
-  console.log( 'on brain id page',val,searchParams)
+  const search = typeof searchParams.search === 'string' ? searchParams.search : undefined;
 
-  // const items = await getBrainAll(brainId);
-  // get all items for that brain and tag them with brainId:all
-
-
-  const brainDetails = await getBrainDetails(val.BrainId);
-
-const items = []
+  const items = await getBrainItems(BrainId, undefined, search);
 
   return (
-    <>
-    <div  >
-    <BrainHeader
-        brainId={val.BrainId}
-        name={brainDetails.name}
-        description={brainDetails.description}
-        counts={brainDetails.counts}
-        isPublic
-        shareUrl="https://app.example.com/share/atlas-123"
-        extensionUrl="https://chromewebstore.google.com/detail/your-extension-id"
-      />
-    <div>specific brain pagellllll</div>
+    <div className="space-y-4">
+      <ItemList items={items} />
     </div>
-    </>
   );
 }

--- a/src/types/brain.ts
+++ b/src/types/brain.ts
@@ -16,6 +16,22 @@ export type SectionItem = {
   createdAt?: string;
 };
 
+export type BrainItemType = 'tweet' | 'video' | 'note' | 'link' | 'other' | 'youtube';
+
+export type BrainItem = {
+  id: string;
+  brainId: string;
+  title: string;
+  type: BrainItemType;
+  url?: string;
+  content?: string;
+  tags: string[];
+  pinned: boolean;
+  createdAt: string;
+  thumbnail?: string; // e.g. for videos
+  author?: string;    // e.g. for tweets
+};
+
 /**
  * A single brain entry for sidebar navigation and feature availability flags.
  */


### PR DESCRIPTION
Implemented the core dashboard functionality for Phase 0.
- Added support for fetching and displaying brain items.
- Created UI components for item cards and lists.
- Set up a nested layout for the brain dashboard to persist the header.
- Implemented routing for specific content sections (tweets, videos, docs, links).
- Added server actions for sharing and inviting collaborators.
- Wired up the BrainHeader to the new actions (though `isPublic` status remains client-side/TODO pending backend support).
- Verified UI with Playwright.

---
*PR created automatically by Jules for task [6025426521098091137](https://jules.google.com/task/6025426521098091137) started by @Ab-hinav*